### PR TITLE
Add notebooks demonstrating loading products and fix Landsat naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv/
 .venv-test
 ENV/
 datacube.conf
+*.tif

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,12 @@ help:
 	@echo "  make rm-product P=<product.yaml>     - Remove a specific product definition"
 	@echo ""
 	@echo "${GREEN}Indexing Commands:${NC}"
-	@echo "  make index-sentinel2a      - Index Sentinel-2 L2A data with the following defaults:"
+	@echo "  make index-sentinel2      - Index Sentinel-2 L2A data with the following defaults:"
 	@echo "                               Bbox  (default: $(Bbox))"
 	@echo "                               Date  (default: $(Date))"
 	@echo ""
 	@echo "  To override these defaults, pass new values as variables."
-	@echo "  For example: ${GREEN}make index-sentinel2a Bbox='115,-10,117,-8' Date='2021-01-01/2021-01-31'${NC}"
+	@echo "  For example: ${GREEN}make index-sentinel2 Bbox='115,-10,117,-8' Date='2021-01-01/2021-01-31'${NC}"
 	@echo ""
 	@echo "${GREEN}Testing Commands:${NC}"
 	@echo "  make test                   - Run all tests with minimal output"
@@ -247,35 +247,42 @@ LANDSATLOOK ?= https://landsatlook.usgs.gov/stac-server/
 
 # Default parameters for indexing
 Bbox ?= 114,-9,116,-7
-Date ?= 2020-01-01/2020-03-31
+Date ?= 2025-01-01/2025-05-30
 CollectionS2 ?= sentinel-2-l2a
 
 # Default parameters for LSX indexing (adjust these as appropriate)
 BboxLs ?= 112,-10,118,-6
-DateLs ?= 2025-01-01/2025-03-31
-DateLsOld ?= 2000-01-01/2000-03-31
+DateLsOld ?= 2000-01-01/2000-06-30
 CollectionLsSR ?= landsat-c2l2-sr
 CollectionLsST ?= landsat-c2l2-st
 
-.PHONY: index-sentinel2a index-ls9-st
+.PHONY: index-sentinel2 index-ls9-st index-ls8-st index-ls7-st index-ls5-st \
+	index-ls9-sr index-ls8-sr index-ls7-sr index-ls5-sr index-all
 
-index-sentinel2a:
+# Index all products
+index-all: index-sentinel2 index-ls9-st index-ls8-st index-ls7-st index-ls5-st \
+	index-ls9-sr index-ls8-sr index-ls7-sr index-ls5-sr
+	@echo "$(GREEN)All products indexed successfully!$(NC)"
+
+# Sentinel-2 L2A
+index-sentinel2:
 	@echo "$(BLUE)Indexing Sentinel-2 L2A data...$(NC)"
 	$(DOCKER_COMPOSE) exec odc \
 	  stac-to-dc --catalog-href='https://earth-search.aws.element84.com/v1/' \
 	            --bbox='$(Bbox)' \
 	            --collections='$(CollectionS2)' \
 	            --datetime='$(Date)' \
-	            --rename-product='sentinel_2_l2a'
+	            --rename-product='s2_l2a'
 
+# Landsat Surface Temperature
 index-ls9-st:
 	@echo "$(BLUE)Indexing LS9 C2L2 ST data...$(NC)"
 	$(DOCKER_COMPOSE) exec odc \
 	  stac-to-dc --catalog-href='${LANDSATLOOK}' \
 	            --bbox='$(Bbox)' \
 	            --collections='$(CollectionLsST)' \
-	            --datetime='$(DateLs)' \
-	            --rename-product='ls9_st' \
+	            --datetime='$(Date)' \
+	            --rename-product='ls9_c2l2_st' \
 	            --limit=100 \
 	            --options="query={\"platform\":{\"in\":[\"LANDSAT_9\"]}}" \
 
@@ -286,8 +293,8 @@ index-ls8-st:
 	  stac-to-dc --catalog-href='${LANDSATLOOK}' \
 	            --bbox='$(Bbox)' \
 	            --collections='$(CollectionLsST)' \
-	            --datetime='$(DateLs)' \
-	            --rename-product='ls8_st' \
+	            --datetime='$(Date)' \
+	            --rename-product='ls8_c2l2_st' \
 	            --limit=100 \
 	            --options="query={\"platform\":{\"in\":[\"LANDSAT_8\"]}}" \
 
@@ -298,7 +305,7 @@ index-ls7-st:
 	            --bbox='$(Bbox)' \
 	            --collections='$(CollectionLsST)' \
 	            --datetime='$(DateLsOld)' \
-	            --rename-product='ls7_st' \
+	            --rename-product='ls7_c2l2_st' \
 	            --limit=100 \
 	            --options="query={\"platform\":{\"in\":[\"LANDSAT_7\"]}}" \
 
@@ -309,9 +316,56 @@ index-ls5-st:
 	            --bbox='$(Bbox)' \
 	            --collections='$(CollectionLsST)' \
 	            --datetime='$(DateLsOld)' \
-	            --rename-product='ls5_st' \
+	            --rename-product='ls5_c2l2_st' \
 	            --limit=100 \
 	            --options="query={\"platform\":{\"in\":[\"LANDSAT_5\"]}}" \
+
+# Landsat Surface Reflectance
+index-ls9-sr:
+	@echo "$(BLUE)Indexing LS9 C2L2 SR data...$(NC)"
+	$(DOCKER_COMPOSE) exec odc \
+	  stac-to-dc --catalog-href='${LANDSATLOOK}' \
+	            --bbox='$(Bbox)' \
+	            --collections='$(CollectionLsSR)' \
+	            --datetime='$(Date)' \
+	            --rename-product='ls9_c2l2_sr' \
+	            --limit=100 \
+	            --options="query={\"platform\":{\"in\":[\"LANDSAT_9\"]}}" \
+
+
+index-ls8-sr:
+	@echo "$(BLUE)Indexing LS8 C2L2 SR data...$(NC)"
+	$(DOCKER_COMPOSE) exec odc \
+	  stac-to-dc --catalog-href='${LANDSATLOOK}' \
+	            --bbox='$(Bbox)' \
+	            --collections='$(CollectionLsSR)' \
+	            --datetime='$(Date)' \
+	            --rename-product='ls8_c2l2_sr' \
+	            --limit=100 \
+	            --options="query={\"platform\":{\"in\":[\"LANDSAT_8\"]}}" \
+
+index-ls7-sr:
+	@echo "$(BLUE)Indexing LS7 C2L2 SR data...$(NC)"
+	$(DOCKER_COMPOSE) exec odc \
+	  stac-to-dc --catalog-href='${LANDSATLOOK}' \
+	            --bbox='$(Bbox)' \
+	            --collections='$(CollectionLsSR)' \
+	            --datetime='$(DateLsOld)' \
+	            --rename-product='ls7_c2l2_sr' \
+	            --limit=100 \
+	            --options="query={\"platform\":{\"in\":[\"LANDSAT_7\"]}}" \
+
+index-ls5-sr:
+	@echo "$(BLUE)Indexing LS5 C2L2 SR data...$(NC)"
+	$(DOCKER_COMPOSE) exec odc \
+	  stac-to-dc --catalog-href='${LANDSATLOOK}' \
+	            --bbox='$(Bbox)' \
+	            --collections='$(CollectionLsSR)' \
+	            --datetime='$(DateLsOld)' \
+	            --rename-product='ls5_c2l2_sr' \
+	            --limit=100 \
+	            --options="query={\"platform\":{\"in\":[\"LANDSAT_5\"]}}" \
+
 
 # Utility commands
 .PHONY: bash-odc bash-jupyter jupyter-token

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
     restart: always
     ports:
-      - 5432
+      - 5432:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s

--- a/notebooks/Landsat_GettingStarted.ipynb
+++ b/notebooks/Landsat_GettingStarted.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Landsat\n",
+    "\n",
+    "This notebook is a very simple example of the fundamentals of working with\n",
+    "Earth observation data using the Open Data Cube.\n",
+    "\n",
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datacube import Datacube\n",
+    "from datacube.utils.aws import configure_s3_access\n",
+    "from odc.geo.geom import point\n",
+    "\n",
+    "from utils import patch_usgs_landsat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "configure_s3_access(requester_pays=True)\n",
+    "\n",
+    "dc = Datacube()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick a study area"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find a location you're interested in on Google Maps and copy the coordinates\n",
+    "# by right-clicking on the map and clicking the coordinates\n",
+    "\n",
+    "# These coords are in the order Y then X, or Latitude then Longitude\n",
+    "coords = -8.6252, 115.2048  # Denpasar, Bali\n",
+    "aoi_point = point(coords[1], coords[0], crs=\"EPSG:4326\")\n",
+    "bbox = aoi_point.buffer(0.2).boundingbox\n",
+    "\n",
+    "landsat_stretch = dict(vmin=7500, vmax=12000)\n",
+    "\n",
+    "datetime = \"2025-03\"\n",
+    "\n",
+    "# Preview the area\n",
+    "bbox.explore(zoom=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data\n",
+    "\n",
+    "This uses the Datacube library to handle loading of the actual data. The `dask_chunks` argument instructs the tool to use Dask\n",
+    "to lazy-load the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = dc.load(\n",
+    "    product=\"ls9_c2l2_sr\",\n",
+    "    measurements=[\"red\", \"green\", \"blue\"],\n",
+    "    output_crs=\"EPSG:32750\",\n",
+    "    resolution=30,\n",
+    "    time=datetime,\n",
+    "    longitude=(bbox.left, bbox.right),\n",
+    "    latitude=(bbox.bottom, bbox.top),\n",
+    "    dask_chunks={\"time\": 1, \"x\": 512, \"y\": 512},\n",
+    "    group_by=\"solar_day\",\n",
+    "    patch_url=patch_usgs_landsat\n",
+    ")\n",
+    "\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualise data\n",
+    "\n",
+    "This step uses `matplotlib` to view data as a static image. It takes a longer time to\n",
+    "run than previous steps, because it's actually loading the data to prepare the images.\n",
+    "\n",
+    "The `to_array()` function is a trick used to be able to visualise the data as a\n",
+    "red, green, blue \"true colour\" image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.to_array().plot.imshow(col=\"time\", col_wrap=2, size=6, **landsat_stretch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interactive map\n",
+    "\n",
+    "This step uses another `odc` tool to visualise the data on a map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best = data.sel(time=\"2025-03-17\").squeeze()\n",
+    "\n",
+    "# The odc.explore function will choose red, green and blue by default\n",
+    "# but you can choose bands with the bands=[\"b1\", \"b2\", \"b3\"] argument\n",
+    "best.odc.explore(**landsat_stretch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export data\n",
+    "\n",
+    "Here we write data to disk, again using an `odc` tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rgba = best.odc.to_rgba(**landsat_stretch)\n",
+    "rgba.odc.write_cog(\"landsat_example.tif\", overwrite=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Landsat_ST_GettingStarted.ipynb
+++ b/notebooks/Landsat_ST_GettingStarted.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Landsat Surface Temperature\n",
+    "\n",
+    "This notebook is a very simple example of the fundamentals of working with\n",
+    "Earth observation data using the Open Data Cube.\n",
+    "\n",
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datacube import Datacube\n",
+    "from datacube.utils.aws import configure_s3_access\n",
+    "from datacube.utils import masking\n",
+    "from odc.geo.geom import point\n",
+    "\n",
+    "from utils import patch_usgs_landsat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "configure_s3_access(requester_pays=True)\n",
+    "\n",
+    "dc = Datacube()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick a study area"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find a location you're interested in on Google Maps and copy the coordinates\n",
+    "# by right-clicking on the map and clicking the coordinates\n",
+    "\n",
+    "# These coords are in the order Y then X, or Latitude then Longitude\n",
+    "coords = -8.6252, 115.2048  # Denpasar, Bali\n",
+    "aoi_point = point(coords[1], coords[0], crs=\"EPSG:4326\")\n",
+    "bbox = aoi_point.buffer(0.05).boundingbox\n",
+    "\n",
+    "landsat_stretch = dict(vmin=7500, vmax=12000)\n",
+    "\n",
+    "datetime = \"2025\"\n",
+    "\n",
+    "# Preview the area\n",
+    "bbox.explore(zoom=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data\n",
+    "\n",
+    "This uses the Datacube library to handle loading of the actual data. The `dask_chunks` argument instructs the tool to use Dask\n",
+    "to lazy-load the data.\n",
+    "\n",
+    "Here we mask out clouds, which interfere with the temperature, and then convert to degrees celcius."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = dc.load(\n",
+    "    product=\"ls9_c2l2_st\",\n",
+    "    measurements=[\"st\", \"qa_pixel\"],\n",
+    "    output_crs=\"EPSG:32750\",\n",
+    "    resolution=30,\n",
+    "    time=datetime,\n",
+    "    longitude=(bbox.left, bbox.right),\n",
+    "    latitude=(bbox.bottom, bbox.top),\n",
+    "    dask_chunks={\"time\": 1, \"x\": 512, \"y\": 512},\n",
+    "    group_by=\"solar_day\",\n",
+    "    patch_url=patch_usgs_landsat\n",
+    ")\n",
+    "\n",
+    "# Select clouds\n",
+    "mask, _ = masking.create_mask_value(\n",
+    "    data[\"qa_pixel\"].attrs[\"flags_definition\"], cloud=\"high_confidence\", cloud_shadow=\"high_confidence\"\n",
+    ")\n",
+    "\n",
+    "pq_mask = (data[\"qa_pixel\"] & mask) != 0\n",
+    "nodata = data.st == 0\n",
+    "mask = pq_mask | nodata\n",
+    "\n",
+    "# Combine the masks\n",
+    "data = data.where(~mask)\n",
+    "\n",
+    "data[\"st\"] = data.st * 0.00341802 + 149.0 - 273.15\n",
+    "\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualise data\n",
+    "\n",
+    "This step uses `matplotlib` to view data as a static image. It takes a longer time to\n",
+    "run than previous steps, because it's actually loading the data to prepare the images.\n",
+    "\n",
+    "The `to_array()` function is a trick used to be able to visualise the data as a\n",
+    "red, green, blue \"true colour\" image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.st.plot.imshow(col=\"time\", col_wrap=2, size=4, cmap=\"coolwarm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a spatial mean and plot a timeseries\n",
+    "clean = data.st.dropna(dim=\"time\", how=\"all\")\n",
+    "mean = clean.mean(dim=(\"x\", \"y\")).compute()\n",
+    "mean.plot.line(x=\"time\", size=4, color=\"black\", label=\"Mean\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export data\n",
+    "\n",
+    "Here we write data to disk, again using an `odc` tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rgba = best.odc.to_rgba(**landsat_stretch)\n",
+    "rgba.odc.write_cog(\"landsat_example.tif\", overwrite=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Sentinel-2_GettingStarted.ipynb
+++ b/notebooks/Sentinel-2_GettingStarted.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Sentinel-2\n",
+    "\n",
+    "This notebook is a very simple example of the fundamentals of working with\n",
+    "Earth observation data using the Open Data Cube.\n",
+    "\n",
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datacube import Datacube\n",
+    "from odc.geo.geom import point"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dc = Datacube()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick a study area"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find a location you're interested in on Google Maps and copy the coordinates\n",
+    "# by right-clicking on the map and clicking the coordinates\n",
+    "\n",
+    "# These coords are in the order Y then X, or Latitude then Longitude\n",
+    "coords = -8.6252, 115.2048  # Denpasar, Bali\n",
+    "aoi_point = point(coords[1], coords[0], crs=\"EPSG:4326\")\n",
+    "bbox = aoi_point.buffer(0.1).boundingbox\n",
+    "\n",
+    "landsat_stretch = dict(vmin=1000, vmax=4000)\n",
+    "\n",
+    "datetime = \"2025-03-01/2025-03-14\"\n",
+    "\n",
+    "# Preview the area\n",
+    "bbox.explore(zoom=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data\n",
+    "\n",
+    "This uses the Datacube library to handle loading of the actual data. The `dask_chunks` argument instructs the tool to use Dask\n",
+    "to lazy-load the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = dc.load(\n",
+    "    product=\"s2_l2a\",\n",
+    "    measurements=[\"red\", \"green\", \"blue\"],\n",
+    "    output_crs=\"EPSG:32750\",\n",
+    "    resolution=10,\n",
+    "    time=(\"2025-03-01\", \"2025-03-14\"),\n",
+    "    x=(float(bbox.left), float(bbox.right)),\n",
+    "    y=(float(bbox.bottom), float(bbox.top)),\n",
+    "    dask_chunks={},\n",
+    "    group_by=\"solar_day\",\n",
+    ")\n",
+    "\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datacube\n",
+    "import dask\n",
+    "import distributed\n",
+    "\n",
+    "print(\"Datacube version:\", datacube.__version__)\n",
+    "print(\"Dask version:\", dask.__version__)\n",
+    "print(\"Dask distributed version:\", distributed.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualise data\n",
+    "\n",
+    "This step uses `matplotlib` to view data as a static image. It takes a longer time to\n",
+    "run than previous steps, because it's actually loading the data to prepare the images.\n",
+    "\n",
+    "The `to_array()` function is a trick used to be able to visualise the data as a\n",
+    "red, green, blue \"true colour\" image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.to_array().plot.imshow(col=\"time\", col_wrap=2, size=6, vmin=0, vmax=3000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interactive map\n",
+    "\n",
+    "This step uses another `odc` tool to visualise the data on a map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best = data.sel(time=\"2025-03-12\").squeeze()\n",
+    "visualisation = best.odc.to_rgba(vmin=0, vmax=3000)\n",
+    "\n",
+    "visualisation.odc.explore()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export data\n",
+    "\n",
+    "Here we write data to disk, again using an `odc` tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visualisation.odc.write_cog(\"sentinel2_example.tif\", overwrite=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/utils.py
+++ b/notebooks/utils.py
@@ -1,0 +1,11 @@
+def patch_usgs_landsat(url: str) -> str:
+    """
+    Patch the USGS Landsat URL to use S3:// instead of HTTPS://.
+
+    Args:
+        url (str): The original URL.
+
+    Returns:
+        str: The patched URL.
+    """
+    return url.replace("https://landsatlook.usgs.gov/data", "s3://usgs-landsat")

--- a/products/lsX_c2l2_sr.odc-product.yaml
+++ b/products/lsX_c2l2_sr.odc-product.yaml
@@ -1,68 +1,62 @@
 ---
-name: ls9_c2l2_st
-description: USGS Landsat 9 Collection 2 Level-2 Surface Temperature
+name: ls9_c2l2_sr
+description: USGS Landsat 9 Collection 2 Level-2 Surface Reflectance
 metadata_type: eo3
 
 license: CC-BY-4.0
 
 metadata:
   product:
-    name: ls9_c2l2_st
+    name: ls9_c2l2_sr
 
 measurements:
-  - name: lwir11
-    units: "Kelvin"
+  - name: coastal
     dtype: "uint16"
+    units: "1"
     nodata: 0
-    aliases: [ST_B10, band_10, st, surface_temperature]
+    aliases: [SR_B1, band_1, coastal_aerosol]
 
-  - name: TRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_TRAD, trad, thermal_radiance]
-
-  - name: URAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_URAD, urad, upwell_radiance]
-
-  - name: DRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_DRAD, drad, downwell_radiance]
-
-  - name: ATRAN
-    dtype: "int16"
+  - name: blue
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_ATRAN, atran, atmospheric_transmittance]
+    nodata: 0
+    aliases: [SR_B2, band_2]
 
-  - name: EMIS
-    dtype: "int16"
+  - name: green
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMIS, emis, emissivity]
+    nodata: 0
+    aliases: [SR_B3, band_3]
 
-  - name: EMSD
-    dtype: "int16"
+  - name: red
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMSD, emsd, emissivity_stddev]
+    nodata: 0
+    aliases: [SR_B4, band_4]
 
-  - name: CDIST
-    dtype: "int16"
-    units: "Kilometers"
-    nodata: -9999
-    aliases: [ST_CDIST, cdist, cloud_distance]
+  - name: nir08
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B5, band_5]
+
+  - name: swir16
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B6, band_6, swir_1]
+
+  - name: swir22
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B7, band_7, swir_2]
 
   - name: qa_pixel
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [QA_PIXEL, pq, pixel_quality]
+    aliases: [pixel_qa, pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -137,7 +131,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [QA_RADSAT,radsat, radiometric_saturation]
+    aliases: [QA_RADSAT, radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -210,76 +204,99 @@ measurements:
           0: false
           1: true
 
-  - name: qa
-    dtype: "int16"
-    units: "Kelvin"
-    nodata: -9999
-    aliases: [ST_QA, st_qa, surface_temperature_quality]
+  - name: qa_aerosol
+    dtype: "uint8"
+    units: "bit_index"
+    nodata: 1
+    aliases: [SR_QA_AEROSOL, qa_aerosol, aerosol_qa]
+    flags_definition:
+      nodata:
+        bits: 0
+        values:
+          0: false
+          1: true
+      valid_aerosol_retrieval:
+        bits: 1
+        values:
+          0: false
+          1: true
+      water:
+        bits: 2
+        values:
+          0: false
+          1: true
+      interpolated_aerosol:
+        bits: 5
+        values:
+          0: false
+          1: true
+      aerosol_level:
+        bits: [6, 7]
+        values:
+          0: climatology
+          1: low
+          2: medium
+          3: high
+
 ---
-name: ls8_c2l2_st
-description: USGS Landsat 8 Collection 2 Level-2 Surface Temperature
+name: ls8_c2l2_sr
+description: USGS Landsat 8 Collection 2 Level-2 Surface Reflectance
 metadata_type: eo3
 
 license: CC-BY-4.0
 
 metadata:
   product:
-    name: ls8_c2l2_st
+    name: ls8_c2l2_sr
 
 measurements:
-  - name: lwir11
-    units: "Kelvin"
+  - name: coastal
     dtype: "uint16"
+    units: "1"
     nodata: 0
-    aliases: [ST_B10, band_10, st, surface_temperature]
+    aliases: [SR_B1, band_1, coastal_aerosol]
 
-  - name: TRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_TRAD, trad, thermal_radiance]
-
-  - name: URAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_URAD, urad, upwell_radiance]
-
-  - name: DRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_DRAD, drad, downwell_radiance]
-
-  - name: ATRAN
-    dtype: "int16"
+  - name: blue
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_ATRAN, atran, atmospheric_transmittance]
+    nodata: 0
+    aliases: [SR_B2, band_2]
 
-  - name: EMIS
-    dtype: "int16"
+  - name: green
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMIS, emis, emissivity]
+    nodata: 0
+    aliases: [SR_B3, band_3]
 
-  - name: EMSD
-    dtype: "int16"
+  - name: red
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMSD, emsd, emissivity_stddev]
+    nodata: 0
+    aliases: [SR_B4, band_4]
 
-  - name: CDIST
-    dtype: "int16"
-    units: "Kilometers"
-    nodata: -9999
-    aliases: [ST_CDIST, cdist, cloud_distance]
+  - name: nir08
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B5, band_5]
+
+  - name: swir16
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B6, band_6, swir_1]
+
+  - name: swir22
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B7, band_7, swir_2]
 
   - name: qa_pixel
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [QA_PIXEL, pq, pixel_quality]
+    aliases: [pixel_qa, pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -354,7 +371,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [QA_RADSAT,radsat, radiometric_saturation]
+    aliases: [QA_RADSAT, radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -427,70 +444,87 @@ measurements:
           0: false
           1: true
 
-  - name: qa
-    dtype: "int16"
-    units: "Kelvin"
-    nodata: -9999
-    aliases: [ST_QA, st_qa, surface_temperature_quality]
+  - name: qa_aerosol
+    dtype: "uint8"
+    units: "bit_index"
+    nodata: 1
+    aliases: [SR_QA_AEROSOL, qa_aerosol, aerosol_qa]
+    flags_definition:
+      nodata:
+        bits: 0
+        values:
+          0: false
+          1: true
+      valid_aerosol_retrieval:
+        bits: 1
+        values:
+          0: false
+          1: true
+      water:
+        bits: 2
+        values:
+          0: false
+          1: true
+      interpolated_aerosol:
+        bits: 5
+        values:
+          0: false
+          1: true
+      aerosol_level:
+        bits: [6, 7]
+        values:
+          0: climatology
+          1: low
+          2: medium
+          3: high
+
 ---
-name: ls7_c2l2_st
-description: USGS Landsat 7 Collection 2 Level-2 Surface Temperature
+name: ls7_c2l2_sr
+description: USGS Landsat 7 Collection 2 Level-2 Surface Reflectance
 metadata_type: eo3
 
 license: CC-BY-4.0
 
 metadata:
   product:
-    name: ls7_c2l2_st
+    name: ls7_c2l2_sr
 
 measurements:
-  - name: lwir
-    units: "Kelvin"
+  - name: blue
     dtype: "uint16"
+    units: "1"
     nodata: 0
-    aliases: [ST_B6, band_6, st, surface_temperature]
+    aliases: [SR_B1, band_1]
 
-  - name: TRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_TRAD, trad, thermal_radiance]
-
-  - name: URAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_URAD, urad, upwell_radiance]
-
-  - name: DRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_DRAD, drad, downwell_radiance]
-
-  - name: ATRAN
-    dtype: "int16"
+  - name: green
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_ATRAN, atran, atmospheric_transmittance]
+    nodata: 0
+    aliases: [SR_B2, band_2]
 
-  - name: EMIS
-    dtype: "int16"
+  - name: red
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMIS, emis, emissivity]
+    nodata: 0
+    aliases: [SR_B3, band_3]
 
-  - name: EMSD
-    dtype: "int16"
+  - name: nir08
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMSD, emsd, emissivity_stddev]
+    nodata: 0
+    aliases: [SR_B4, band_4, nir]
 
-  - name: CDIST
-    dtype: "int16"
-    units: "Kilometers"
-    nodata: -9999
-    aliases: [ST_CDIST, cdist, cloud_distance]
+  - name: swir16
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B5, band_5, swir_1]
+
+  - name: swir22
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B7, band_7, swir_2]
 
   - name: qa_pixel
     dtype: "uint16"
@@ -508,11 +542,6 @@ measurements:
         values:
           0: not_dilated
           1: dilated
-      cirrus:
-        bits: 2
-        values:
-          0: not_high_confidence
-          1: high_confidence
       cloud:
         bits: 3
         values:
@@ -559,19 +588,12 @@ measurements:
           1: low
           2: reserved
           3: high
-      cirrus_confidence:
-        bits: [14, 15]
-        values:
-          0: none
-          1: low
-          2: reserved
-          3: high
 
   - name: qa_radsat
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [QA_RADSAT,radsat, radiometric_saturation]
+    aliases: [QA_RADSAT, radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -598,7 +620,7 @@ measurements:
         values:
           0: false
           1: true
-      band_6_saturation:
+      band_6L_saturation:
         bits: 5
         values:
           0: false
@@ -608,28 +630,43 @@ measurements:
         values:
           0: false
           1: true
+      band_6H_saturation:
+        bits: 8
+        values:
+          0: false
+          1: true
       blue_saturation:
-        bits: 1
+        bits: 0
         values:
           0: false
           1: true
       green_saturation:
-        bits: 2
+        bits: 1
         values:
           0: false
           1: true
       red_saturation:
-        bits: 3
+        bits: 2
         values:
           0: false
           1: true
       nir_saturation:
-        bits: 4
+        bits: 3
         values:
           0: false
           1: true
       swir_1_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      tir_l_saturation:
         bits: 5
+        values:
+          0: false
+          1: true
+      tir_h_saturation:
+        bits: 8
         values:
           0: false
           1: true
@@ -638,76 +675,102 @@ measurements:
         values:
           0: false
           1: true
-      terrain_occlusion:
-        bits: 11
+      dropped_pixel:
+        bits: 9
         values:
           0: false
           1: true
 
-  - name: qa
+  - name: atmos_opacity
     dtype: "int16"
-    units: "Kelvin"
+    units: "1"
     nodata: -9999
-    aliases: [ST_QA, st_qa, surface_temperature_quality]
+    aliases: [SR_ATMOS_OPACITY, atmos_opacity]
+
+  - name: cloud_qa
+    dtype: "uint8"
+    units: "bit_index"
+    nodata: 0
+    aliases: [SR_CLOUD_QA]
+    flags_definition:
+      dark_dense_vegetation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      cloud:
+        bits: 1
+        values:
+          0: false
+          1: true
+      cloud_shadow:
+        bits: 2
+        values:
+          0: false
+          1: true
+      adjacent_to_cloud:
+        bits: 3
+        values:
+          0: false
+          1: true
+      snow:
+        bits: 4
+        values:
+          0: false
+          1: true
+      water:
+        bits: 5
+        values:
+          0: false
+          1: true
+
 ---
-name: ls5_c2l2_st
-description: USGS Landsat 5 Collection 2 Level-2 Surface Temperature
+name: ls5_c2l2_sr
+description: USGS Landsat t Collection 2 Level-2 Surface Reflectance
 metadata_type: eo3
 
 license: CC-BY-4.0
 
 metadata:
   product:
-    name: ls5_c2l2_st
+    name: ls5_c2l2_sr
 
 measurements:
-  - name: lwir
-    units: "Kelvin"
+  - name: blue
     dtype: "uint16"
+    units: "1"
     nodata: 0
-    aliases: [ST_B6, band_6, st, surface_temperature]
+    aliases: [SR_B1, band_1]
 
-  - name: TRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_TRAD, trad, thermal_radiance]
-
-  - name: URAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_URAD, urad, upwell_radiance]
-
-  - name: DRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [ST_DRAD, drad, downwell_radiance]
-
-  - name: ATRAN
-    dtype: "int16"
+  - name: green
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_ATRAN, atran, atmospheric_transmittance]
+    nodata: 0
+    aliases: [SR_B2, band_2]
 
-  - name: EMIS
-    dtype: "int16"
+  - name: red
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMIS, emis, emissivity]
+    nodata: 0
+    aliases: [SR_B3, band_3]
 
-  - name: EMSD
-    dtype: "int16"
+  - name: nir08
+    dtype: "uint16"
     units: "1"
-    nodata: -9999
-    aliases: [ST_EMSD, emsd, emissivity_stddev]
+    nodata: 0
+    aliases: [SR_B4, band_4, nir]
 
-  - name: CDIST
-    dtype: "int16"
-    units: "Kilometers"
-    nodata: -9999
-    aliases: [ST_CDIST, cdist, cloud_distance]
+  - name: swir16
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B5, band_5, swir_1]
+
+  - name: swir22
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [SR_B7, band_7, swir_2]
 
   - name: qa_pixel
     dtype: "uint16"
@@ -725,11 +788,6 @@ measurements:
         values:
           0: not_dilated
           1: dilated
-      cirrus:
-        bits: 2
-        values:
-          0: not_high_confidence
-          1: high_confidence
       cloud:
         bits: 3
         values:
@@ -776,19 +834,12 @@ measurements:
           1: low
           2: reserved
           3: high
-      cirrus_confidence:
-        bits: [14, 15]
-        values:
-          0: none
-          1: low
-          2: reserved
-          3: high
 
   - name: qa_radsat
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [QA_RADSAT,radsat, radiometric_saturation]
+    aliases: [QA_RADSAT, radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -826,26 +877,31 @@ measurements:
           0: false
           1: true
       blue_saturation:
-        bits: 1
+        bits: 0
         values:
           0: false
           1: true
       green_saturation:
-        bits: 2
+        bits: 1
         values:
           0: false
           1: true
       red_saturation:
-        bits: 3
+        bits: 2
         values:
           0: false
           1: true
       nir_saturation:
-        bits: 4
+        bits: 3
         values:
           0: false
           1: true
       swir_1_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      tir_saturation:
         bits: 5
         values:
           0: false
@@ -855,14 +911,51 @@ measurements:
         values:
           0: false
           1: true
-      terrain_occlusion:
-        bits: 11
+      dropped_pixel:
+        bits: 9
         values:
           0: false
           1: true
 
-  - name: qa
+  - name: atmos_opacity
     dtype: "int16"
-    units: "Kelvin"
+    units: "1"
     nodata: -9999
-    aliases: [ST_QA, st_qa, surface_temperature_quality]
+    aliases: [SR_ATMOS_OPACITY, atmos_opacity]
+
+  - name: cloud_qa
+    dtype: "uint8"
+    units: "bit_index"
+    nodata: 0
+    aliases: [SR_CLOUD_QA]
+    flags_definition:
+      dark_dense_vegetation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      cloud:
+        bits: 1
+        values:
+          0: false
+          1: true
+      cloud_shadow:
+        bits: 2
+        values:
+          0: false
+          1: true
+      adjacent_to_cloud:
+        bits: 3
+        values:
+          0: false
+          1: true
+      snow:
+        bits: 4
+        values:
+          0: false
+          1: true
+      water:
+        bits: 5
+        values:
+          0: false
+          1: true

--- a/products/s2_l2a.odc-product.yaml
+++ b/products/s2_l2a.odc-product.yaml
@@ -1,12 +1,12 @@
 ---
-name: sentinel_2_l2a
-description: Sentinel-2a and Sentinel-2b imagery, processed to Level
+name: s2_l2a
+description: Sentinel-2a, Sentinel-2b and Sentinel-2c imagery, processed to Level
   2A (Surface Reflectance) and converted to Cloud Optimized GeoTIFFs
 metadata_type: eo3
 
 metadata:
   product:
-    name: sentinel_2_l2a
+    name: s2_l2a
 
 measurements:
   - name: "coastal"


### PR DESCRIPTION
Changes the following:

- Renames Landsat products to be clearer that it's level 2 surface reflectance
- Adds example indexing of Landsat SR
- Adds a notebook loading Landsat SR, ST and Sentinel-2 data.