### PR TITLE
Update mini-piksel with more regions and a metadata definition

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ODC_DEFAULT_DB_PORT=${POSTGRES_PORT:-5432}
     volumes:
       - ../products:/home/venv/products
+      - ../metadata:/home/venv/metadata
     depends_on:
       postgres:
         condition: service_healthy

--- a/metadata/custom_metadata.odc-type.yaml
+++ b/metadata/custom_metadata.odc-type.yaml
@@ -1,0 +1,151 @@
+name: eo3
+description: EO for DE Africa
+dataset:
+  id: ['id']                               # has to be this value, can't be changed
+  sources: ['lineage', 'source_datasets']  # has to be this value, can't be changed
+  grid_spatial: ['grid_spatial', 'projection']
+  measurements: ['measurements']
+  creation_dt: ['properties', 'odc:processing_datetime']
+  label: ['label']
+  format: ['properties', 'odc:file_format']  # note add to ARD metadata, only L1 currently
+
+  search_fields:
+    platform:
+      description: Platform code
+      offset: ['properties', 'eo:platform']
+
+    instrument:
+      description: Instrument name
+      offset: ['properties', 'eo:instrument']
+
+    product_family:
+      description: Product family code
+      offset: ['properties', 'odc:product_family']
+
+    region_code:
+      description: >
+        Spatial reference code from the provider.
+        For Landsat region_code is a scene path row '{:03d}{:03d}.format(path,row)'.
+        For Sentinel it is MGRS code.
+        In general it is a unique string identifier that datasets covering roughly
+        the same spatial region share.
+
+      offset: ['properties', 'odc:region_code']
+
+    cloud_cover:
+      description: Cloud cover percentage [0, 100]
+      type: double
+      offset: ['properties', 'eo:cloud_cover']
+
+    time:
+      description: Acquisition time range
+      type: datetime-range
+      min_offset:
+        - ['properties', 'dtr:start_datetime']
+        - ['properties', 'datetime']
+      max_offset:
+        - ['properties', 'dtr:end_datetime']
+        - ['properties', 'datetime']
+
+    lon:
+      description: Longitude range
+      type: double-range
+      min_offset:
+        - ['extent', 'lon', 'begin']
+      max_offset:
+        - ['extent', 'lon', 'end']
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - ['extent', 'lat', 'begin']
+      max_offset:
+        - ['extent', 'lat', 'end']
+
+    # Frequently used fields
+    eo_gsd:
+      description: The ground sample distance
+      indexed: false
+      offset:
+      - properties
+      - eo:gsd
+      type: double
+
+    eo_sun_azimuth:
+      description: Sun azimuth
+      indexed: false
+      offset:
+      - properties
+      - eo:sun_azimuth
+      type: double
+
+    eo_sun_elevation:
+      description: Sun elevation
+      indexed: false
+      offset:
+      - properties
+      - eo:sun_elevation
+      type: double
+
+    # Custom DE Africa Fields
+    # Generic
+    crs_raw:
+      description: Coordinate reference system field
+      offset: ['properties', 'crs']
+      indexed: false
+
+    # Sentinel-1
+    sat_orbit_state:
+      description: The satellite orbit state, either ascending or descending
+      offset: ['properties', 'sat:orbit_state']
+      indexed: false
+    
+    sat_relative_orbit:
+      description: The satellite relative orbit
+      offset: ['properties', 'sat:relative_orbit']
+      indexed: false
+      type: integer
+
+    # Sentinel-2
+    data_coverage:
+      description: How much data is in the scene
+      offset: ['properties', 'sentinel:data_coverage']
+      indexed: false
+      type: double
+
+    # Landsat
+    collection_category:
+      description: Landsat collection category, such as T1 or T2
+      offset: ['properties', 'landsat:collection_category']
+      indexed: false
+
+    rmse:
+      description: Landsat root mean square error
+      offset: ['properties', 'landsat:rmse']
+      indexed: false
+      type: double
+
+    rmse_x:
+      description: Landsat root mean square error in X
+      offset: ['properties', 'landsat:rmse_x']
+      indexed: false
+      type: double
+
+    rmse_y:
+      description: Landsat root mean square error in Y
+      offset: ['properties', 'landsat:rmse_y']
+      indexed: false
+      type: double
+
+    # Derivatives
+    dataset_version:
+      description: Derived product version number
+      offset: ['properties', 'odc:dataset_version']
+      indexed: false
+    
+    # Crop mask or other regional products
+    region:
+      description: African regional area
+      offset: ['properties', 'region']
+      indexed: false


### PR DESCRIPTION
Hey @taufik-shf I need you to apply the `metadata` definition in here.

You can do that with `datacube metadata update --allow-unsafe <path-to-yaml>`.

We need this for the workshop, as it allows us to filter by USGS Tier and by Cloud Cover percentage.