### PR TITLE
Fix flood hazard product definition and add indexing target

### DIFF
--- a/products/flood_hazard.odc-product.yaml
+++ b/products/flood_hazard.odc-product.yaml
@@ -35,6 +35,7 @@ measurements:
     flags_definition:
       hazard:
         description: Flood hazard class
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
         values:
           1: low
           2: moderate
@@ -72,6 +73,7 @@ measurements:
     flags_definition:
       hazard:
         description: Flood hazard class
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
         values:
           1: low
           2: moderate
@@ -109,6 +111,7 @@ measurements:
     flags_definition:
       hazard:
         description: Flood hazard class
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
         values:
           1: low
           2: moderate
@@ -146,6 +149,7 @@ measurements:
     flags_definition:
       hazard:
         description: Flood hazard class
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
         values:
           1: low
           2: moderate
@@ -183,6 +187,7 @@ measurements:
     flags_definition:
       hazard:
         description: Flood hazard class
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
         values:
           1: low
           2: moderate


### PR DESCRIPTION
Adds the schema-required `bits` key to the `flood_hazard_class` flags definition, without which ODC rejects all five products. Switches the float measurements to NaN nodata, because 3.4e38 is not representable in float32 and so never compared equal to the stored pixels; the COGs in S3 have been rewritten to match. Adds `make index-flood-hazard` to index the return-period products from S3.